### PR TITLE
Bugfix for macOS detection

### DIFF
--- a/builddeb.sh
+++ b/builddeb.sh
@@ -59,4 +59,5 @@ exec docker run \
     -e BUILD_UID="$UID" \
     -e BUILD_GNAME="$(id -g -n)" \
     -e BUILD_GID="$(id -g)" \
+    -e DOCKER_HOST_OSTYPE="$OSTYPE" \
     "${CONTAINER}"

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ cd /tmp/deps
 mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' "$WORK/$PACKAGE/debian/control"
 cd "$WORK/$PACKAGE"
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$DOCKER_HOST_OSTYPE" == "darwin"* ]]; then
     cp -r /root/gnupg /root/.gnupg
     
     # On macOS we can just start the build and get the files with macOS owner

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-in
 cd "$WORK/$PACKAGE"
 
 if [[ "$DOCKER_HOST_OSTYPE" == "darwin"* ]]; then
-    cp -r /root/gnupg /root/.gnupg
+    ln -s /root/gnupg /root/.gnupg
     
     # On macOS we can just start the build and get the files with macOS owner
     ${BUILD_CMD}


### PR DESCRIPTION
Sorry, something went wrong. The OSTYPE variable of the Dockerhost must of course be given into the container via a Docker variable. In addition, the .gnupg folder can also have sockets on macOS (depending on the installed extra software) and we cannot copy them. Since we are root users anyway, I would just solve it, like here, via ln.