### PR TITLE
feat: Copy artifacts, if --git-export-dir argument is set

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,10 @@ cd /tmp/deps
 mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' "$WORK/$PACKAGE/debian/control"
 cd "$WORK/$PACKAGE"
 
+# Check for argument '--git-export-dir' to copy artifacts to work dir after BUILD_CMD
+# The regex will find a pure path or a path in lead characters, which can also contain spaces.
+GIT_EXPORT_DIR=$(echo ${BUILD_CMD} | grep -oP -- "(?<=--git-export-dir=)((['\"].+?['\"])+|[^ ]+)")
+
 if [[ "$DOCKER_HOST_OSTYPE" == "darwin"* ]]; then
     ln -s /root/gnupg /root/.gnupg
     
@@ -38,4 +42,11 @@ else
 
     # And start the package build as the created user
     su -c "${BUILD_CMD}" "${BUILD_UNAME}"
+fi
+
+# For visual style, we deactivate the debug output of bash at this point
+set +x
+if [ -n "${GIT_EXPORT_DIR}" ]; then
+    echo "INFO: Found git-export-dir argument, copy package files to ${WORK}"
+    find "${GIT_EXPORT_DIR}" -type f -exec cp {} ${WORK} \;
 fi


### PR DESCRIPTION
In rare cases, it can happen that the build on the mapped file system of the host system fails. This could happen, for example, through changed permissions. To circumvent this, e.g. for gbp, the parameter git-export-dir can be specified. The packages are then built in the file system by the Docker container. The resulting packets must be copied from the container file system to the host file system at the end.

The regex will find a pure path of --git-export-dir= or a path in lead characters, which can also contain spaces.