### PR TITLE
Ignore exit code of grep to find git-export-dir

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,7 +26,7 @@ cd "$WORK/$PACKAGE"
 
 # Check for argument '--git-export-dir' to copy artifacts to work dir after BUILD_CMD
 # The regex will find a pure path or a path in lead characters, which can also contain spaces.
-GIT_EXPORT_DIR=$(echo ${BUILD_CMD} | grep -oP -- "(?<=--git-export-dir=)((['\"].+?['\"])+|[^ ]+)")
+GIT_EXPORT_DIR=$(echo ${BUILD_CMD} | grep -oP -- "(?<=--git-export-dir=)((['\"].+?['\"])+|[^ ]+)" || true)
 
 if [[ "$DOCKER_HOST_OSTYPE" == "darwin"* ]]; then
     ln -s /root/gnupg /root/.gnupg


### PR DESCRIPTION
Sorry dude!

During the tests, I still had the lines under the "set +x" and moved them so that the visual experience is better. Unfortunately, of course, the script aborts if grep does not find "--git-export-dir=" at EXPORT_DIR.

This solves the problem.

Caused-by: 82f0594