### PR TITLE
fix: Specify docker.io registry explicitly

### DIFF
--- a/bookworm/Dockerfile
+++ b/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM docker.io/debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM docker.io/debian:buster
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/revpi-bookworm/Dockerfile
+++ b/revpi-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM tianon/raspbian:bookworm
+FROM docker.io/tianon/raspbian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/revpi-bullseye/Dockerfile
+++ b/revpi-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM tianon/raspbian:bullseye
+FROM docker.io/tianon/raspbian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/revpi-buster/Dockerfile
+++ b/revpi-buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM tianon/raspbian:buster
+FROM docker.io/tianon/raspbian:buster
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/revpi64-bookworm/Dockerfile
+++ b/revpi64-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:bookworm
+FROM docker.io/arm64v8/debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/revpi64-bullseye/Dockerfile
+++ b/revpi64-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:bullseye
+FROM docker.io/arm64v8/debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Other container runtimes than Docker might not use docker.io as their default container registry, or any for that matter (i.e. podman). To make the Dockerfiles work with them they should explicitly say where they pull the image from.