### PR TITLE
fix: Specify missing docker.io for bullseye

### DIFF
--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM docker.io/debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Fixes: f57e838 ("fix: Specify docker.io registry explicitly")